### PR TITLE
Update Docker Base Image for Dependency Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM python:2.7.8-onbuild
-CMD [ "python", "datapusher/main.py", "deployment/datapusher_settings.py"]
+FROM python:2.7-onbuild
+CMD ["python", "datapusher/main.py", "deployment/datapusher_settings.py"]


### PR DESCRIPTION
Encountered a build issue when using the Docker image. The older Python version had difficulties with the PyPI URL.

Updated the Docker image from python:2.7.8-onbuild to python:2.7-onbuild to address the PyPI URL issue.  
